### PR TITLE
Add and Update interactive tutorial modal for P3R/P5R

### DIFF
--- a/p3r/index.html
+++ b/p3r/index.html
@@ -40,10 +40,10 @@
                 <span></span>
             </button>
             <ul id="nav-list">
+                <li><a href="#" id="tutorial-trigger">Ajuda (Tutorial)</a></li>
                 <li><a href="../p5r/index.html">Persona 5 Royal</a></li>
                 <li><a href="p3r.html" class="active">Persona 3 Reload</a></li>
                 <li><a href="p3r-guess.html" class="minigame-nav-link">🎮 Persona Guess</a></li>
-                <li><a href="#">Persona 4 <span class="dev-tag">Em Breve</span></a></li>
             </ul>
         </nav>
     </header>
@@ -133,6 +133,136 @@
             </div>
         </div>
     </div>
+
+
+<!-- ================== TUTORIAL MODAL P3R STYLE ================== -->
+<div id="tutorial-overlay" class="tutorial-overlay">
+    <!-- Fragmentos de vidro decorativos em neon azul -->
+    <div class="tut-bg-shards">
+        <span></span><span></span><span></span>
+        <span></span><span></span><span></span>
+    </div>
+    <div class="tutorial-card" id="tutorial-card">
+        <!-- Barra de progresso superior -->
+        <div class="tut-progress-bar">
+            <div class="tut-progress-fill" id="tut-progress-fill"></div>
+        </div>
+        <!-- Indicador de slide -->
+        <div class="tut-step-indicator" id="tut-step-indicator">
+            <span class="tut-dot active" data-step="0"></span>
+            <span class="tut-dot" data-step="1"></span>
+            <span class="tut-dot" data-step="2"></span>
+            <span class="tut-dot" data-step="3"></span>
+            <span class="tut-dot" data-step="4"></span>
+        </div>
+        <!-- Conteúdo dos slides -->
+        <div class="tut-slides-wrapper" id="tut-slides-wrapper">
+            <!-- SLIDE 0 — Boas-vindas -->
+            <div class="tut-slide active" data-slide="0">
+                <div class="tut-speaker-tag">ELIZABETH</div>
+                <div class="tut-icon">&#129419;</div>
+                <h2 class="tut-title typewriter" id="tut-title-0">Boas-vindas a Sala de Veludo.</h2>
+                <p class="tut-body">
+                    Este aposento existe entre o sonho e a realidade, mente e matéria...<br><br>
+                    No <strong>Persona Fusion Hub</strong>, organizamos os dados das fusões de 
+                    <strong>Persona 3 Reload</strong> para ajudá-lo a guiar o seu destino antes de adentrar a terrível <strong>Hora Sombria</strong>.
+                </p>
+                <div class="tut-flavor">
+                    "Meu nome é Elizabeth. Sou uma residente deste aposento..."
+                </div>
+            </div>
+            <!-- SLIDE 1 — O que é Persona 3 -->
+            <div class="tut-slide" data-slide="1">
+                <div class="tut-speaker-tag">IGOR</div>
+                <div class="tut-icon">&#9670;</div>
+                <h2 class="tut-title" id="tut-title-1">Máscaras da Alma</h2>
+                <p class="tut-body">
+                    Personas são as forças do seu coração, máscaras psíquicas manifestadas para combater as Sombras do <strong>Tartarus</strong>.<br><br>
+                    Cada Persona pertence a uma <strong>Arcana</strong> das cartas de Tarô. Fundir duas delas na Velvet Room consome seus contratos e gera um aliado muito mais poderoso.
+                </p>
+                <div class="tut-arcana-preview">
+                    <span>Fool</span><span>Magician</span><span>Priestess</span>
+                    <span>Empress</span><span>Emperor</span><span>Hierophant</span>
+                    <span>Lovers</span><span>Chariot</span><span>Justice</span>
+                    <span>+ Arcanas</span>
+                </div>
+            </div>
+            <!-- SLIDE 2 — Calculadora Normal -->
+            <div class="tut-slide" data-slide="2">
+                <div class="tut-speaker-tag">ELIZABETH</div>
+                <div class="tut-icon">⚔</div>
+                <h2 class="tut-title" id="tut-title-2">Fusão de Díades</h2>
+                <p class="tut-body">
+                    Na nossa calculadora principal, você pode simular a combinação direta de duas Personas para prever qual entidade herdará seus poderes.
+                </p>
+                <div class="tut-steps-visual">
+                    <div class="tut-step-item">
+                        <div class="tut-step-num">①</div>
+                        <div>Selecione a primeira Persona no campo <em>Persona 1</em></div>
+                    </div>
+                    <div class="tut-step-item">
+                        <div class="tut-step-num">②</div>
+                        <div>Selecione a segunda Persona no campo <em>Persona 2</em></div>
+                    </div>
+                    <div class="tut-step-item">
+                        <div class="tut-step-num">③</div>
+                        <div>Clique em <em>"Calcular Fusão"</em> para ver o resultado</div>
+                    </div>
+                    <div class="tut-step-item">
+                        <div class="tut-step-num">④</div>
+                        <div>Clique no resultado para conferir seus Atributos e Afinidades Elementais</div>
+                    </div>
+                </div>
+            </div>
+            <!-- SLIDE 3 — Calculadora Reversa -->
+            <div class="tut-slide" data-slide="3">
+                <div class="tut-speaker-tag">ELIZABETH</div>
+                <div class="tut-icon">&#128269;</div>
+                <h2 class="tut-title" id="tut-title-3">Calculadora Reversa</h2>
+                <p class="tut-body">
+                    Deseja obter uma Persona específica do compêndio de dados?
+                    A <strong>Calculadora Reversa</strong> busca e lista todos os ingredientes comuns e especiais capazes de gerá-la.
+                </p>
+                <div class="tut-steps-visual">
+                    <div class="tut-step-item">
+                        <div class="tut-step-num">①</div>
+                        <div>Digite o nome da Persona que deseja obter em <em>Persona Alvo</em></div>
+                    </div>
+                    <div class="tut-step-item">
+                        <div class="tut-step-num">②</div>
+                        <div>Clique em <em>"Encontrar Receitas"</em></div>
+                    </div>
+                    <div class="tut-step-item">
+                        <div class="tut-step-num">③</div>
+                        <div>A lista de ingredientes aparecerá direto na tela. Dê um clique em qualquer um deles para abrir seus detalhes!</div>
+                    </div>
+                </div>
+            </div>
+            <!-- SLIDE 4 — Conclusão -->
+            <div class="tut-slide" data-slide="4">
+                <div class="tut-speaker-tag">ELIZABETH</div>
+                <div class="tut-icon">&#9733;</div>
+                <h2 class="tut-title" id="tut-title-4">A Hora Sombria nos Aguarda.</h2>
+                <p class="tut-body">
+                    O compêndio de fusão está atualizado com a API e pronto para uso.<br><br>
+                    Aproveite as fusões para obter imunidades e vantagens de fraquezas elementais cruciais para as noites de lua cheia!
+                </p>
+                <div class="tut-flavor">
+                    "Ficarei extremamente contente se este humilde sistema guiar seus passos..."
+                </div>
+                <label class="tut-remember-label">
+                    <input type="checkbox" id="tut-dont-show"> Não mostrar novamente
+                </label>
+            </div>
+        </div><!-- /tut-slides-wrapper -->
+        <!-- Navegação -->
+        <div class="tut-nav">
+            <button class="tut-btn tut-btn-prev" id="tut-btn-prev" disabled>&#9664; VOLTAR</button>
+            <button class="tut-btn tut-btn-skip" id="tut-btn-skip">PULAR</button>
+            <button class="tut-btn tut-btn-next" id="tut-btn-next">PRÓXIMO &#9654;</button>
+        </div>
+    </div><!-- /tutorial-card -->
+</div><!-- /tutorial-overlay -->
 
     <script src="script.js"></script>
 </body>

--- a/p3r/script.js
+++ b/p3r/script.js
@@ -30,6 +30,140 @@ document.addEventListener('DOMContentLoaded', () => {
 
     const modal = document.getElementById('persona-modal');
     const closeModalBtn = document.getElementById('close-modal-btn');
+    // --- SELETORES DO TUTORIAL P3R ---
+    const p3rTutOverlay       = document.getElementById('tutorial-overlay');
+    const p3rTutSlides        = document.querySelectorAll('.tut-slide');
+    const p3rTutDots          = document.querySelectorAll('.tut-dot');
+    const p3rTutProgressFill  = document.getElementById('tut-progress-fill');
+    const p3rTutBtnPrev       = document.getElementById('tut-btn-prev');
+    const p3rTutBtnSkip       = document.getElementById('tut-btn-skip');
+    const p3rTutBtnNext       = document.getElementById('tut-btn-next');
+    const p3rTutDontShowCheck = document.getElementById('tut-dont-show');
+    const p3rTutTrigger       = document.getElementById('tutorial-trigger');
+
+    let p3rTutCurrentStep = 0;
+
+    // --- FUNÇÃO DE ATUALIZAÇÃO DO SLIDE ---
+    function updateP3RTutorialView() {
+        if (!p3rTutSlides.length) return;
+
+        // Limpa classes ativas dos slides e indicadores
+        p3rTutSlides.forEach(slide => slide.classList.remove('active'));
+        p3rTutDots.forEach(dot => dot.classList.remove('active'));
+
+        // Ativa o slide e dot atual
+        const activeSlide = document.querySelector(`.tut-slide[data-slide="${p3rTutCurrentStep}"]`);
+        const activeDot = document.querySelector(`.tut-dot[data-step="${p3rTutCurrentStep}"]`);
+
+        if (activeSlide) activeSlide.classList.add('active');
+        if (activeDot) activeDot.classList.add('active');
+
+        // Atualiza preenchimento da barra de progresso (0% a 100%)
+        const progressPercent = (p3rTutCurrentStep / (p3rTutSlides.length - 1)) * 100;
+        if (p3rTutProgressFill) {
+            p3rTutProgressFill.style.width = `${progressPercent}%`;
+        }
+
+        // Controla o estado de bloqueio do botão Voltar
+        if (p3rTutBtnPrev) {
+            p3rTutBtnPrev.disabled = p3rTutCurrentStep === 0;
+        }
+
+        // Altera o texto do botão de avanço final
+        if (p3rTutBtnNext) {
+            if (p3rTutCurrentStep === p3rTutSlides.length - 1) {
+                p3rTutBtnNext.innerHTML = 'ENTENDIDO &#9654;';
+            } else {
+                p3rTutBtnNext.innerHTML = 'PRÓXIMO &#9654;';
+            }
+        }
+    }
+
+    // --- CONTROLE DE EXIBIÇÃO ---
+    function openP3RTutorial() {
+        p3rTutCurrentStep = 0;
+        updateP3RTutorialView();
+        if (p3rTutOverlay) {
+            p3rTutOverlay.style.display = 'flex';
+            p3rTutOverlay.classList.add('active');
+        }
+    }
+
+    function closeP3RTutorial() {
+        // Guarda a preferência de não exibição se o checkbox estiver ativo
+        if (p3rTutDontShowCheck && p3rTutDontShowCheck.checked) {
+            localStorage.setItem('p3r_tutorial_seen', 'true');
+        }
+        if (p3rTutOverlay) {
+            p3rTutOverlay.style.display = 'none';
+            p3rTutOverlay.classList.remove('active');
+        }
+    }
+
+    // --- CONFIGURAÇÃO DOS EVENT LISTENERS ---
+
+    // Botão de Avanço
+    if (p3rTutBtnNext) {
+        p3rTutBtnNext.addEventListener('click', () => {
+            if (p3rTutCurrentStep < p3rTutSlides.length - 1) {
+                p3rTutCurrentStep++;
+                updateP3RTutorialView();
+            } else {
+                closeP3RTutorial();
+            }
+        });
+    }
+
+    // Botão Voltar
+    if (p3rTutBtnPrev) {
+        p3rTutBtnPrev.addEventListener('click', () => {
+            if (p3rTutCurrentStep > 0) {
+                p3rTutCurrentStep--;
+                updateP3RTutorialView();
+            }
+        });
+    }
+
+    // Botão Pular
+    if (p3rTutBtnSkip) {
+        p3rTutBtnSkip.addEventListener('click', () => {
+            closeP3RTutorial();
+        });
+    }
+
+    // Navegação manual por cliques nas bolinhas
+    p3rTutDots.forEach(dot => {
+        dot.addEventListener('click', (e) => {
+            const step = parseInt(e.target.getAttribute('data-step'), 10);
+            if (!isNaN(step)) {
+                p3rTutCurrentStep = step;
+                updateP3RTutorialView();
+            }
+        });
+    });
+
+    // Link de Ajuda na barra de cabeçalho
+    if (p3rTutTrigger) {
+        p3rTutTrigger.addEventListener('click', (e) => {
+            e.preventDefault();
+            openP3RTutorial();
+        });
+    }
+
+    // --- VERIFICAÇÃO DE PRIMEIRO ACESSO ---
+    function checkP3RFirstTimeTutorial() {
+        const seen = localStorage.getItem('p3r_tutorial_seen');
+        if (!seen) {
+            openP3RTutorial();
+        } else {
+            if (p3rTutOverlay) {
+                p3rTutOverlay.style.display = 'none';
+            }
+        }
+    }
+
+    // Dispara a verificação 1.5s após a conclusão das animações do seu Loader
+    setTimeout(checkP3RFirstTimeTutorial, 1500);
 
     let selectedPersonas = { persona1: null, persona2: null, target: null };
     let personas = [];

--- a/p3r/style.css
+++ b/p3r/style.css
@@ -314,6 +314,251 @@ button:hover::before { left: 0; }
 .modal-section li {
     display: flex; justify-content: space-between; padding: 8px 10px; border-bottom: 1px solid rgba(255,255,255,0.05); font-size: 0.95em;
 }
+/* Estilo do Tutorial Overlay - Tema P3R Glassmorphism */
+.tutorial-overlay {
+    --p3-blue: #0088ff;
+    --p3-cyan: #00e5ff;
+    --p3-bg: #030816;
+    --p3-panel: #0a1128;
+    --p3-border: rgba(0, 229, 255, 0.3);
+    --p3-text: #cbd5e1;
+    --p3-white: #ffffff;
+    
+    position: fixed;
+    top: 0; left: 0;
+    width: 100%; height: 100%;
+    background-color: rgba(3, 8, 22, 0.85);
+    backdrop-filter: blur(8px);
+    z-index: 9000;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    transition: opacity 0.4s ease;
+}
+
+.tutorial-card {
+    background-color: var(--p3-panel);
+    border: 2px solid var(--p3-cyan);
+    box-shadow: 0 0 25px rgba(0, 229, 255, 0.2);
+    width: 90%;
+    max-width: 600px;
+    padding: 30px;
+    position: relative;
+    border-radius: 12px;
+    color: var(--p3-text);
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+}
+
+/* Barra de progresso em neon azul */
+.tut-progress-bar {
+    width: 100%;
+    height: 6px;
+    background-color: #1e293b;
+    border-radius: 3px;
+    overflow: hidden;
+}
+
+.tut-progress-fill {
+    width: 0%;
+    height: 100%;
+    background-color: var(--p3-cyan);
+    box-shadow: 0 0 10px var(--p3-cyan);
+    transition: width 0.3s ease;
+}
+
+/* Slides */
+.tut-slides-wrapper {
+    min-height: 280px;
+    position: relative;
+}
+
+.tut-slide {
+    display: none;
+    flex-direction: column;
+    gap: 15px;
+    animation: fadeInTut 0.3s ease-in-out forwards;
+}
+
+.tut-slide.active {
+    display: flex;
+}
+
+@keyframes fadeInTut {
+    from { opacity: 0; transform: translateY(10px); }
+    to { opacity: 1; transform: translateY(0); }
+}
+
+.tut-speaker-tag {
+    font-size: 0.9em;
+    font-weight: bold;
+    color: var(--p3-cyan);
+    letter-spacing: 2px;
+    text-transform: uppercase;
+    text-shadow: 0 0 5px rgba(0, 229, 255, 0.5);
+}
+
+.tut-icon {
+    font-size: 1.5em;
+    color: var(--p3-cyan);
+}
+
+.tut-title {
+    font-family: 'Exo 2', sans-serif;
+    font-size: 1.8em;
+    font-weight: 900;
+    color: var(--p3-white);
+}
+
+.tut-body {
+    font-size: 1.05em;
+    line-height: 1.6;
+    color: #94a3b8;
+}
+
+.tut-flavor {
+    font-style: italic;
+    font-size: 0.9em;
+    color: #64748b;
+    border-left: 2px solid var(--p3-blue);
+    padding-left: 10px;
+}
+
+.tut-arcana-preview {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    margin-top: 10px;
+}
+
+.tut-arcana-preview span {
+    background-color: #1e293b;
+    color: var(--p3-cyan);
+    padding: 3px 8px;
+    border-radius: 4px;
+    font-size: 0.85em;
+    font-weight: bold;
+    border: 1px solid rgba(0, 229, 255, 0.1);
+}
+
+/* Indicadores */
+.tut-step-indicator {
+    display: flex;
+    justify-content: center;
+    gap: 10px;
+}
+
+.tut-dot {
+    width: 10px;
+    height: 10px;
+    background-color: #1e293b;
+    border-radius: 50%;
+    cursor: pointer;
+    transition: 0.2s ease;
+    border: 1px solid var(--p3-border);
+}
+
+.tut-dot.active {
+    background-color: var(--p3-cyan);
+    box-shadow: 0 0 8px var(--p3-cyan);
+    transform: scale(1.2);
+}
+
+/* Elementos de etapas do tutorial */
+.tut-steps-visual {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    text-align: left;
+}
+
+.tut-step-item {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+
+.tut-step-num {
+    background-color: var(--p3-cyan);
+    color: #000;
+    font-weight: bold;
+    width: 24px; height: 24px;
+    border-radius: 50%;
+    display: flex; align-items: center; justify-content: center;
+    flex-shrink: 0;
+}
+
+.tut-remember-label {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 0.9em;
+    color: #64748b;
+    cursor: pointer;
+    margin-top: 10px;
+}
+
+/* Navegação do tutorial */
+.tut-nav {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.tut-btn {
+    background: transparent;
+    border: 1px solid var(--p3-cyan);
+    color: var(--p3-cyan);
+    padding: 10px 20px;
+    font-family: 'Exo 2', sans-serif;
+    font-weight: bold;
+    border-radius: 6px;
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+
+.tut-btn:hover:not(:disabled) {
+    background-color: var(--p3-cyan);
+    color: #000;
+    box-shadow: 0 0 10px rgba(0, 229, 255, 0.4);
+}
+
+.tut-btn:disabled {
+    opacity: 0.3;
+    cursor: not-allowed;
+    border-color: #334155;
+    color: #334155;
+}
+
+.tut-btn-skip {
+    border-color: transparent;
+    color: #64748b;
+}
+
+.tut-btn-skip:hover {
+    color: var(--p3-white);
+}
+
+/* Partículas Decorativas de Shards */
+.tut-bg-shards {
+    position: absolute; width: 100%; height: 100%; top: 0; left: 0; overflow: hidden; pointer-events: none; z-index: -1;
+}
+.tut-bg-shards span {
+    position: absolute; display: block; width: 8px; height: 8px; background: rgba(0, 229, 255, 0.1); transform: rotate(45deg); bottom: -10px; animation: shardsUp 8s infinite linear;
+}
+.tut-bg-shards span:nth-child(1) { left: 10%; width: 12px; height: 12px; animation-delay: 0s; }
+.tut-bg-shards span:nth-child(2) { left: 30%; animation-delay: 2s; animation-duration: 10s; }
+.tut-bg-shards span:nth-child(3) { left: 50%; width: 6px; height: 6px; animation-delay: 4s; }
+.tut-bg-shards span:nth-child(4) { left: 70%; animation-delay: 1s; }
+.tut-bg-shards span:nth-child(5) { left: 85%; width: 14px; height: 14px; animation-delay: 5s; }
+
+@keyframes shardsUp {
+    0% { transform: translateY(0) rotate(45deg); opacity: 0; }
+    50% { opacity: 0.7; }
+    100% { transform: translateY(-110vh) rotate(405deg); opacity: 0; }
+}
 
 /* Responsividade */
 @media (min-width: 992px) {

--- a/p5r/index.html
+++ b/p5r/index.html
@@ -12,8 +12,114 @@
     <link rel="icon" type="image/x-icon" href="./images/favicon.ico">
 </head>
 <body>
+     <!-- ================== LOADER ================== -->
+    <div id="p5-loader">
+        <div class="loader-content">
+            <div class="loader-text" id="loader-text">CONNECTING TO VELVET ROOM...</div>
+            <div class="loader-bar-container">/
+                <div class="loader-bar" id="loader-bar"></div>
+            </div>
+            <div class="loader-percent" id="loader-percent">0%</div>
+        </div>
+        <div class="loader-bg-pattern"></div>
+    </div>
 
-    <!-- ================== TUTORIAL MODAL P5 STYLE ================== -->
+    <!-- ================== HEADER ================== -->
+    <header>
+        <div class="header-content">
+            <div class="logo">Persona Fusion Hub</div>
+            <nav>
+                <button class="hamburger" id="hamburger-menu">
+                    <span></span><span></span><span></span>
+                </button>
+                <ul id="nav-list">
+                    <li><a href="#" id="tutorial-trigger">Ajuda (Tutorial)</a></li>
+                    <li><a href="#" class="active">Persona 5 Royal</a></li>
+                    <li><a href="../p3r/index.html">Persona 3 Reload</a></li>
+                    <li><a href="#">Persona 4 <span class="dev-tag">Em Breve</span></a></li>
+                </ul>
+            </nav>
+        </div>
+    </header>
+
+<div class="calculators-wrapper">
+        <!-- ================== CALCULADORA NORMAL ================== -->
+        <div class="calculator-container">
+            <h1>Guilhotina de Fusão</h1>
+            <p>Selecione dois prisioneiros para a execução na Velvet Room.</p>
+
+            <div class="selection-area">
+                <div class="search-container">
+                    <label for="search-input-1">Prisioneiro 1</label>
+                    <input type="text" id="search-input-1" class="search-input" placeholder="Digite o nome..." autocomplete="off">
+                    <div class="results-container" id="results-container-1"></div>
+                </div>
+
+                <span class="plus-sign">+</span>
+
+                <div class="search-container">
+                    <label for="search-input-2">Prisioneiro 2</label>
+                    <input type="text" id="search-input-2" class="search-input" placeholder="Digite o nome..." autocomplete="off">
+                    <div class="results-container" id="results-container-2"></div>
+                </div>
+            </div>
+
+            <button id="calculateBtn">Executar Fusão</button>
+
+            <div id="result-area">
+                <h2>Resultado da Execução</h2>
+                <p id="result-text" style="margin-top: 10px;">O prisioneiro nascerá aqui.</p>
+            </div>
+        </div>
+
+        <!-- ================== CALCULADORA REVERSA ================== -->
+        <div class="reverse-calculator-container">
+            <h2>Busca de Registros</h2>
+            <p>Selecione um prisioneiro para ver suas combinações de execução.</p>
+            
+            <div class="search-container" style="width: 100%;">
+                <label for="reverse-search-input">Prisioneiro Alvo</label>
+                <input type="text" id="reverse-search-input" class="search-input" placeholder="Quem você deseja criar?" autocomplete="off">
+                <div class="results-container" id="reverse-results-container"></div>
+            </div>
+
+            <button id="reverse-calculate-btn">Procurar Registros</button>
+
+            <!-- ================== LISTA DE RECEITAS ================== -->
+            <div id="reverse-result-area" style="margin-top: 30px;">
+                <ul id="reverse-recipes-list" style="list-style: none; padding: 0;"></ul>
+                <p id="reverse-no-results" style="display: none; color: #d60012; font-weight: bold; margin-top: 15px;">
+                    Este prisioneiro não pode ser gerado através de uma execução normal de guilhotina.
+                </p>
+            </div>
+        </div>
+    </div>
+
+    <!-- ================== ÚNICO MODAL ================== -->
+    <div class="modal-overlay" id="persona-modal">
+        <div class="modal-content">
+            <button class="close-modal" id="close-modal-btn">&times;</button>
+            <div class="modal-header">
+                <div>
+                    <h2 id="modal-persona-name">Nome da Persona</h2>
+                    <span id="modal-persona-level" class="level-badge">Lvl 0</span>
+                    <p id="modal-persona-trait" class="persona-trait"></p>
+                </div>
+            </div>
+            <div class="modal-body">
+                <div class="modal-section" id="modal-stats">
+                    <h3>Stats Iniciais</h3>
+                    <ul></ul>
+                </div>
+                <div class="modal-section" id="modal-elements">
+                    <h3>Afinidades Elementais</h3>
+                    <ul></ul>
+                </div>
+            </div>
+        </div>
+    </div>
+
+        <!-- ================== TUTORIAL MODAL P5 STYLE ================== -->
     <div id="tutorial-overlay" class="tutorial-overlay">
 
         <!-- Partículas de fundo decorativas -->
@@ -162,112 +268,6 @@
 
         </div><!-- /tutorial-card -->
     </div><!-- /tutorial-overlay -->
-
-     <!-- ================== LOADER ================== -->
-    <div id="p5-loader">
-        <div class="loader-content">
-            <div class="loader-text" id="loader-text">CONNECTING TO VELVET ROOM...</div>
-            <div class="loader-bar-container">/
-                <div class="loader-bar" id="loader-bar"></div>
-            </div>
-            <div class="loader-percent" id="loader-percent">0%</div>
-        </div>
-        <div class="loader-bg-pattern"></div>
-    </div>
-
-    <!-- ================== HEADER ================== -->
-    <header>
-        <div class="header-content">
-            <div class="logo">Persona Fusion Hub</div>
-            <nav>
-                <button class="hamburger" id="hamburger-menu">
-                    <span></span><span></span><span></span>
-                </button>
-                <ul id="nav-list">
-                    <li><a href="#" class="active">Persona 5 Royal</a></li>
-                    <li><a href="../p3r/index.html">Persona 3 Reload</a></li>
-                    <li><a href="#">Persona 4 <span class="dev-tag">Em Breve</span></a></li>
-                </ul>
-            </nav>
-        </div>
-    </header>
-
-<div class="calculators-wrapper">
-        <!-- ================== CALCULADORA NORMAL ================== -->
-        <div class="calculator-container">
-            <h1>Guilhotina de Fusão</h1>
-            <p>Selecione dois prisioneiros para a execução na Velvet Room.</p>
-
-            <div class="selection-area">
-                <div class="search-container">
-                    <label for="search-input-1">Prisioneiro 1</label>
-                    <input type="text" id="search-input-1" class="search-input" placeholder="Digite o nome..." autocomplete="off">
-                    <div class="results-container" id="results-container-1"></div>
-                </div>
-
-                <span class="plus-sign">+</span>
-
-                <div class="search-container">
-                    <label for="search-input-2">Prisioneiro 2</label>
-                    <input type="text" id="search-input-2" class="search-input" placeholder="Digite o nome..." autocomplete="off">
-                    <div class="results-container" id="results-container-2"></div>
-                </div>
-            </div>
-
-            <button id="calculateBtn">Executar Fusão</button>
-
-            <div id="result-area">
-                <h2>Resultado da Execução</h2>
-                <p id="result-text" style="margin-top: 10px;">O prisioneiro nascerá aqui.</p>
-            </div>
-        </div>
-
-        <!-- ================== CALCULADORA REVERSA ================== -->
-        <div class="reverse-calculator-container">
-            <h2>Busca de Registros</h2>
-            <p>Selecione um prisioneiro para ver suas combinações de execução.</p>
-            
-            <div class="search-container" style="width: 100%;">
-                <label for="reverse-search-input">Prisioneiro Alvo</label>
-                <input type="text" id="reverse-search-input" class="search-input" placeholder="Quem você deseja criar?" autocomplete="off">
-                <div class="results-container" id="reverse-results-container"></div>
-            </div>
-
-            <button id="reverse-calculate-btn">Procurar Registros</button>
-
-            <!-- ================== LISTA DE RECEITAS ================== -->
-            <div id="reverse-result-area" style="margin-top: 30px;">
-                <ul id="reverse-recipes-list" style="list-style: none; padding: 0;"></ul>
-                <p id="reverse-no-results" style="display: none; color: #d60012; font-weight: bold; margin-top: 15px;">
-                    Este prisioneiro não pode ser gerado através de uma execução normal de guilhotina.
-                </p>
-            </div>
-        </div>
-    </div>
-
-    <!-- ================== ÚNICO MODAL ================== -->
-    <div class="modal-overlay" id="persona-modal">
-        <div class="modal-content">
-            <button class="close-modal" id="close-modal-btn">&times;</button>
-            <div class="modal-header">
-                <div>
-                    <h2 id="modal-persona-name">Nome da Persona</h2>
-                    <span id="modal-persona-level" class="level-badge">Lvl 0</span>
-                    <p id="modal-persona-trait" class="persona-trait"></p>
-                </div>
-            </div>
-            <div class="modal-body">
-                <div class="modal-section" id="modal-stats">
-                    <h3>Stats Iniciais</h3>
-                    <ul></ul>
-                </div>
-                <div class="modal-section" id="modal-elements">
-                    <h3>Afinidades Elementais</h3>
-                    <ul></ul>
-                </div>
-            </div>
-        </div>
-    </div>
-    <script src="script.js"></script>
+<script src="script.js"></script>
 </body>
 </html>

--- a/p5r/script.js
+++ b/p5r/script.js
@@ -1,60 +1,199 @@
 document.addEventListener('DOMContentLoaded', () => {
 
-            // =========================================================
-            // LOADER COM BARRA DINÂMICA
-            // =========================================================
-            const loader = document.getElementById('p5-loader');
-            const loaderText = document.querySelector('.loader-text');
-            const loaderBar = document.getElementById('loader-bar');
-            const loaderPercent = document.getElementById('loader-percent');
+    // =========================================================
+    // LOADER COM BARRA DINÂMICA
+    // =========================================================
+    const loader = document.getElementById('p5-loader');
+    const loaderText = document.querySelector('.loader-text');
+    const loaderBar = document.getElementById('loader-bar');
+    const loaderPercent = document.getElementById('loader-percent');
 
-            let progress = 0;
-            const progressInterval = setInterval(() => {
-                progress += Math.random() * 15;
-                if (progress >= 95) progress = 95; // Trava no 95% enquanto a API não responde
-                if (loaderBar) loaderBar.style.width = `${progress}%`;
-                if (loaderPercent) loaderPercent.textContent = `${Math.floor(progress)}%`;
-            }, 200);
+    let progress = 0;
+    const progressInterval = setInterval(() => {
+        progress += Math.random() * 15;
+        if (progress >= 95) progress = 95; // Trava no 95% enquanto a API não responde
+        if (loaderBar) loaderBar.style.width = `${progress}%`;
+        if (loaderPercent) loaderPercent.textContent = `${Math.floor(progress)}%`;
+    }, 200);
 
-            function hideLoader() {
-                if (loader) {
-                    clearInterval(progressInterval);
-                    if (loaderBar) loaderBar.style.width = '100%';
-                    if (loaderPercent) loaderPercent.textContent = '100%';
-                    
-                    setTimeout(() => {
-                        loader.classList.add('slide-out');
-                        setTimeout(() => { loader.style.display = 'none'; }, 600);
-                    }, 400);
-                }
-            }
+    function hideLoader() {
+        if (loader) {
+            clearInterval(progressInterval);
+            if (loaderBar) loaderBar.style.width = '100%';
+            if (loaderPercent) loaderPercent.textContent = '100%';
+            
+            setTimeout(() => {
+                loader.classList.add('slide-out');
+                setTimeout(() => { 
+                    loader.style.display = 'none'; 
+                    // AQUI ESTÁ O SEGREDO: O tutorial só é chamado DEPOIS que o loader some!
+                    checkFirstTimeTutorial(); 
+                }, 600);
+            }, 400);
+        } else {
+            // Caso o loader não exista no HTML por algum motivo
+            checkFirstTimeTutorial();
+        }
+    }
 
-            function setLoaderMessage(msg, isError = false) {
-                if (loaderText) {
-                    loaderText.textContent = msg;
-                    loaderText.style.color = isError ? '#ff4444' : 'var(--p5-white)';
-                }
-            }
+    function setLoaderMessage(msg, isError = false) {
+        if (loaderText) {
+            loaderText.textContent = msg;
+            loaderText.style.color = isError ? '#ff4444' : 'var(--p5-white)';
+        }
+    }
 
-        // =========================================================
-        // ELEMENTOS DOM
-        // =========================================================
-        const searchInput1          = document.getElementById('search-input-1');
-        const resultsContainer1     = document.getElementById('results-container-1');
-        const searchInput2          = document.getElementById('search-input-2');
-        const resultsContainer2     = document.getElementById('results-container-2');
-        const calculateBtn          = document.getElementById('calculateBtn');
-        const resultText            = document.getElementById('result-text');
+    // =========================================================
+    // ELEMENTOS DOM
+    // =========================================================
+    const searchInput1          = document.getElementById('search-input-1');
+    const resultsContainer1     = document.getElementById('results-container-1');
+    const searchInput2          = document.getElementById('search-input-2');
+    const resultsContainer2     = document.getElementById('results-container-2');
+    const calculateBtn          = document.getElementById('calculateBtn');
+    const resultText            = document.getElementById('result-text');
 
-        const reverseSearchInput        = document.getElementById('reverse-search-input');
-        const reverseResultsContainer   = document.getElementById('reverse-results-container');
-        const reverseCalculateBtn       = document.getElementById('reverse-calculate-btn');
-        const reverseRecipeList         = document.getElementById('reverse-recipes-list');
-        const reverseNoResults          = document.getElementById('reverse-no-results');
+    const reverseSearchInput        = document.getElementById('reverse-search-input');
+    const reverseResultsContainer   = document.getElementById('reverse-results-container');
+    const reverseCalculateBtn       = document.getElementById('reverse-calculate-btn');
+    const reverseRecipeList         = document.getElementById('reverse-recipes-list');
+    const reverseNoResults          = document.getElementById('reverse-no-results');
 
     // Modal de detalhe de persona (O único modal que sobrou)
     const modal         = document.getElementById('persona-modal');
     const closeModalBtn = document.getElementById('close-modal-btn');
+    
+    // --- SELETORES DO TUTORIAL ---
+    const tutOverlay       = document.getElementById('tutorial-overlay');
+    const tutSlides        = document.querySelectorAll('.tut-slide');
+    const tutDots          = document.querySelectorAll('.tut-dot');
+    const tutProgressFill  = document.getElementById('tut-progress-fill');
+    const tutBtnPrev       = document.getElementById('tut-btn-prev');
+    const tutBtnSkip       = document.getElementById('tut-btn-skip');
+    const tutBtnNext       = document.getElementById('tut-btn-next');
+    const tutDontShowCheck = document.getElementById('tut-dont-show');
+    const tutTrigger       = document.getElementById('tutorial-trigger');
+
+    let tutCurrentStep = 0;
+
+    // --- FUNÇÃO DE ATUALIZAÇÃO DO SLIDE ---
+    function updateTutorialView() {
+        if (!tutSlides.length) return;
+
+        // Esconde todos os slides e remove estados ativos
+        tutSlides.forEach(slide => slide.classList.remove('active'));
+        tutDots.forEach(dot => dot.classList.remove('active'));
+
+        // Ativa o slide e dot correspondente ao passo atual
+        const activeSlide = document.querySelector(`.tut-slide[data-slide="${tutCurrentStep}"]`);
+        const activeDot = document.querySelector(`.tut-dot[data-step="${tutCurrentStep}"]`);
+
+        if (activeSlide) activeSlide.classList.add('active');
+        if (activeDot) activeDot.classList.add('active');
+
+        // Atualiza a barra de progresso superior (0% a 100%)
+        const progressPercent = (tutCurrentStep / (tutSlides.length - 1)) * 100;
+        if (tutProgressFill) {
+            tutProgressFill.style.width = `${progressPercent}%`;
+        }
+
+        // Controla o estado do botão "Voltar"
+        if (tutBtnPrev) {
+            tutBtnPrev.disabled = tutCurrentStep === 0;
+        }
+
+        // Controla o texto do botão de ação principal "Próximo/Entendido"
+        if (tutBtnNext) {
+            if (tutCurrentStep === tutSlides.length - 1) {
+                tutBtnNext.innerHTML = 'ENTENDIDO &#9654;';
+            } else {
+                tutBtnNext.innerHTML = 'PRÓXIMO &#9654;';
+            }
+        }
+    }
+
+    // --- FUNÇÕES DE CONTROLE DE EXIBIÇÃO ---
+    function openTutorial() {
+        tutCurrentStep = 0;
+        updateTutorialView();
+        if (tutOverlay) {
+            tutOverlay.style.display = 'flex';
+            tutOverlay.classList.add('active'); 
+        }
+    }
+
+    function closeTutorial() {
+        // Verifica se o usuário marcou para não mostrar novamente
+        if (tutDontShowCheck && tutDontShowCheck.checked) {
+            localStorage.setItem('p5r_tutorial_seen', 'true');
+        }
+        if (tutOverlay) {
+            tutOverlay.style.display = 'none';
+            tutOverlay.classList.remove('active');
+        }
+    }
+
+    // --- CONFIGURAÇÃO DOS EVENT LISTENERS DO TUTORIAL ---
+
+    // Botão Avançar / Concluir
+    if (tutBtnNext) {
+        tutBtnNext.addEventListener('click', () => {
+            if (tutCurrentStep < tutSlides.length - 1) {
+                tutCurrentStep++;
+                updateTutorialView();
+            } else {
+                closeTutorial();
+            }
+        });
+    }
+
+    // Botão Voltar
+    if (tutBtnPrev) {
+        tutBtnPrev.addEventListener('click', () => {
+            if (tutCurrentStep > 0) {
+                tutCurrentStep--;
+                updateTutorialView();
+            }
+        });
+    }
+
+    // Botão Pular
+    if (tutBtnSkip) {
+        tutBtnSkip.addEventListener('click', () => {
+            closeTutorial();
+        });
+    }
+
+    // Clique direto nos Dots indicadores
+    tutDots.forEach(dot => {
+        dot.addEventListener('click', (e) => {
+            const step = parseInt(e.target.getAttribute('data-step'), 10);
+            if (!isNaN(step)) {
+                tutCurrentStep = step;
+                updateTutorialView();
+            }
+        });
+    });
+
+    // Gatilho de Ajuda na Barra de Navegação (Abre sempre, ignorando o cache)
+    if (tutTrigger) {
+        tutTrigger.addEventListener('click', (e) => {
+            e.preventDefault();
+            openTutorial();
+        });
+    }
+
+    // --- DISPARO AUTOMÁTICO NO PRIMEIRO ACESSO ---
+    function checkFirstTimeTutorial() {
+        const seen = localStorage.getItem('p5r_tutorial_seen');
+        if (!seen) {
+            openTutorial();
+        } else {
+            if (tutOverlay) {
+                tutOverlay.style.display = 'none';
+            }
+        }
+    }
 
     let selectedPersonas = { persona1: null, persona2: null, target: null };
     let personas = [];
@@ -743,142 +882,8 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     });
 
-    // --- SELETORES DO TUTORIAL ---
-    const tutOverlay       = document.getElementById('tutorial-overlay');
-    const tutSlides        = document.querySelectorAll('.tut-slide');
-    const tutDots          = document.querySelectorAll('.tut-dot');
-    const tutProgressFill  = document.getElementById('tut-progress-fill');
-    const tutBtnPrev       = document.getElementById('tut-btn-prev');
-    const tutBtnSkip       = document.getElementById('tut-btn-skip');
-    const tutBtnNext       = document.getElementById('tut-btn-next');
-    const tutDontShowCheck = document.getElementById('tut-dont-show');
-    const tutTrigger       = document.getElementById('tutorial-trigger');
+   
 
-    let tutCurrentStep = 0;
-
-    // --- FUNÇÃO DE ATUALIZAÇÃO DO SLIDE ---
-    function updateTutorialView() {
-        if (!tutSlides.length) return;
-
-        // Esconde todos os slides e remove estados ativos
-        tutSlides.forEach(slide => slide.classList.remove('active'));
-        tutDots.forEach(dot => dot.classList.remove('active'));
-
-        // Ativa o slide e dot correspondente ao passo atual
-        const activeSlide = document.querySelector(`.tut-slide[data-slide="${tutCurrentStep}"]`);
-        const activeDot = document.querySelector(`.tut-dot[data-step="${tutCurrentStep}"]`);
-
-        if (activeSlide) activeSlide.classList.add('active');
-        if (activeDot) activeDot.classList.add('active');
-
-        // Atualiza a barra de progresso superior (0% a 100%)
-        const progressPercent = (tutCurrentStep / (tutSlides.length - 1)) * 100;
-        if (tutProgressFill) {
-            tutProgressFill.style.width = `${progressPercent}%`;
-        }
-
-        // Controla o estado do botão "Voltar"
-        if (tutBtnPrev) {
-            tutBtnPrev.disabled = tutCurrentStep === 0;
-        }
-
-        // Controla o texto do botão de ação principal "Próximo/Entendido"
-        if (tutBtnNext) {
-            if (tutCurrentStep === tutSlides.length - 1) {
-                tutBtnNext.innerHTML = 'ENTENDIDO &#9654;';
-            } else {
-                tutBtnNext.innerHTML = 'PRÓXIMO &#9654;';
-            }
-        }
-    }
-
-    // --- FUNÇÕES DE CONTROLE DE EXIBIÇÃO ---
-    function openTutorial() {
-        tutCurrentStep = 0;
-        updateTutorialView();
-        if (tutOverlay) {
-            tutOverlay.style.display = 'flex';
-            // Se você utilizou animação de opacidade no CSS, adiciona a classe active
-            tutOverlay.classList.add('active'); 
-        }
-    }
-
-    function closeTutorial() {
-        // Verifica se o usuário marcou para não mostrar novamente
-        if (tutDontShowCheck && tutDontShowCheck.checked) {
-            localStorage.setItem('p5r_tutorial_seen', 'true');
-        }
-        if (tutOverlay) {
-            tutOverlay.style.display = 'none';
-            tutOverlay.classList.remove('active');
-        }
-    }
-
-    // --- CONFIGURAÇÃO DOS EVENT LISTENERS ---
-
-    // Botão Avançar / Concluir
-    if (tutBtnNext) {
-        tutBtnNext.addEventListener('click', () => {
-            if (tutCurrentStep < tutSlides.length - 1) {
-                tutCurrentStep++;
-                updateTutorialView();
-            } else {
-                closeTutorial();
-            }
-        });
-    }
-
-    // Botão Voltar
-    if (tutBtnPrev) {
-        tutBtnPrev.addEventListener('click', () => {
-            if (tutCurrentStep > 0) {
-                tutCurrentStep--;
-                updateTutorialView();
-            }
-        });
-    }
-
-    // Botão Pular
-    if (tutBtnSkip) {
-        tutBtnSkip.addEventListener('click', () => {
-            closeTutorial();
-        });
-    }
-
-    // Clique direto nos Dots indicadores
-    tutDots.forEach(dot => {
-        dot.addEventListener('click', (e) => {
-            const step = parseInt(e.target.getAttribute('data-step'), 10);
-            if (!isNaN(step)) {
-                tutCurrentStep = step;
-                updateTutorialView();
-            }
-        });
-    });
-
-    // Gatilho de Ajuda na Barra de Navegação (Abre sempre, ignorando o cache)
-    if (tutTrigger) {
-        tutTrigger.addEventListener('click', (e) => {
-            e.preventDefault();
-            openTutorial();
-        });
-    }
-
-    // --- DISPARO AUTOMÁTICO NO PRIMEIRO ACESSO ---
-    function checkFirstTimeTutorial() {
-        const seen = localStorage.getItem('p5r_tutorial_seen');
-        if (!seen) {
-            openTutorial();
-        } else {
-            if (tutOverlay) {
-                tutOverlay.style.display = 'none';
-            }
-        }
-    }
-
-    // Injeta a verificação após o término do Loader
-    // Para alinhar com seu carregador, você pode chamar checkFirstTimeTutorial() no final do loadPersonas() ou hideLoader()
-    setTimeout(checkFirstTimeTutorial, 1500); 
 
     // INICIALIZA A APLICAÇÃO E O FETCH DA API
     loadPersonas();


### PR DESCRIPTION
Introduce a reusable tutorial overlay for both Persona 3 Reload and Persona 5 Royal. Added markup for the tutorial modal and a help link in the nav (p3r/index.html, p5r/index.html), comprehensive styling (p3r/style.css) and JavaScript controls for slide navigation, progress bar, dots, skip/remember checkbox and localStorage persistence (p3r/script.js, p5r/script.js). Also integrated the tutorial flow with the P5R loader so the tutorial opens after the loader finishes and removed duplicated HTML blocks in p5r/index.html. The tutorial supports step navigation, manual dot selection and a "don't show again" option.